### PR TITLE
Add Gnome 41 Support (closes #38)

### DIFF
--- a/NotificationFactory.js
+++ b/NotificationFactory.js
@@ -80,7 +80,10 @@ var NotificationFactory = class {
      * @private
      */
     _newErrorSource() {
-        if (this._errorSource !== undefined) this._errorSource.destroy();
+        if (this._errorSource !== undefined) {
+            this.sources.delete(this._errorSource);
+            this._errorSource.destroy();
+        }
         const source = new Source(this._mailbox, 'dialog-error');
         this.sources.add(source);
         return source;
@@ -120,6 +123,9 @@ var NotificationFactory = class {
             } catch (err) {
                 console.error(err);
             }
+        });
+        notification.connect('destroy', (destroyed_source) => {
+            this.sources.delete(destroyed_source.source);
         });
 
         if (permanent) {

--- a/extension.js
+++ b/extension.js
@@ -65,6 +65,7 @@ var Extension = class {
             this.startTimeout();
             this.initialCheckMail = GLib.timeout_add_seconds(0, 5, () => {
                 this._checkMail();
+                this.initialCheckMail = null;
                 return false;
             });
         });
@@ -133,7 +134,7 @@ var Extension = class {
      */
     stopTimeout() {
         Mainloop.source_remove(this.checkMailTimeout);
-        Mainloop.source_remove(this.initialCheckMail);
+        if (this.initialCheckMail !== null) Mainloop.source_remove(this.initialCheckMail);
     }
 
     /**

--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,9 @@
   "name": "Gnome Email Notifications",
   "description": "Shows Gmail and Outlook notifications in Gnome Message Tray using Gnome Online Accounts\n",
   "shell-version": [
-    "40"
+    "41"
   ],
   "url": "https://github.com/shumingch/gnome-email-notifications",
   "uuid": "GmailMessageTray@shuming0207.gmail.com",
-  "version": 22
+  "version": 23
 }

--- a/prefs.js
+++ b/prefs.js
@@ -139,7 +139,10 @@ function buildPrefsWidget() {
 var Prefs = GObject.registerClass(class extends Gtk.Box {
     _init(params) {
         super._init(params);
-        this.margin = 24;
+        this.margin_start = 24;
+        this.margin_end = 24;
+        this.margin_top = 16;
+        this.margin_bottom = 16;
         this.orientation = Gtk.Orientation.VERTICAL;
         this._conf = new Conf();
         const useMailLabel = _("Use default email client instead of browser");
@@ -173,6 +176,8 @@ var Prefs = GObject.registerClass(class extends Gtk.Box {
         const setting_label = new Gtk.Label({
             label: label,
             xalign: 0,
+            margin_top: 2,
+            margin_bottom: 2,
             use_markup: true
         });
         setting_label.set_tooltip_text(help);
@@ -183,6 +188,10 @@ var Prefs = GObject.registerClass(class extends Gtk.Box {
             const setting_radio_button = new Gtk.ToggleButton({
                 group: previous_radio_button,
                 label: d.display,
+                margin_top: 2,
+                margin_bottom: 2,
+                margin_start: 20,
+                margin_end: 20,
                 active: this._conf.getGmailSystemLabel() === d.value
             })
             previous_radio_button = setting_radio_button
@@ -205,6 +214,7 @@ var Prefs = GObject.registerClass(class extends Gtk.Box {
     _addSwitchSetting(label, help) {
         const hbox = this._createHBox();
         const setting_switch = new Gtk.CheckButton({
+            margin_start: 2,
             active: this._conf.getReader() === 1
         });
         setting_switch.connect('toggled', button => {
@@ -221,7 +231,11 @@ var Prefs = GObject.registerClass(class extends Gtk.Box {
      * @private
      */
     _createHBox() {
-        return new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL });
+        return new Gtk.Box({ 
+            orientation: Gtk.Orientation.HORIZONTAL, 
+            margin_top: 2,
+            margin_bottom: 2
+        });
     }
 
     /**


### PR DESCRIPTION
## Add Gnome 41 Support (closes #38)
#### metadata.json
Updates supported shell version to 41.
## Add margins to preferences dialog
#### prefs.js (mutiple locations)
Adds margins.
#### prefs.js, line 142
GtkWidget's margin property has been removed.
See https://docs.gtk.org/gtk4/migrating-3to4.html#stop-using-gtkbox-padding-fill-and-expand-child-properties.
Margins must now be set individually. 
## Fix errors when extension is disabled
#### extensions.js, line 68
Deletes the reference to an automatically destroyed timeout.
See https://gjs-docs.gnome.org/glib20~2.66.1/glib.timeout_add_seconds.
#### extensions.js, line 137
The timeout is automatically destroyed when it returns false.
Prevents the extension from trying to destroy the timeout again.
#### NotificationFactory.js, line 83
Deletes the old error source from the collection of active sources before destroying it.
#### NotificationFactory.js, line 127
Deletes the reference to a destroyed notification.