### PR TITLE
Closes #25

### DIFF
--- a/InboxScanner.js
+++ b/InboxScanner.js
@@ -101,8 +101,10 @@ var InboxScanner = class {
                 const [, token] = this._account.get_oauth2_based().call_get_access_token_finish(asyncResult);
                 callback(token);
             } catch (err) {
-                const message = _("Failed to get Authorization for {0}");
-                Main.notifyError(message.replace("{0}", this._mailbox));
+                if (!err.message.includes("Goa.Error.Failed")) {
+                    const message = _("Failed to get Authorization for {0}");
+                    Main.notifyError(message.replace("{0}", this._mailbox));
+                }
                 console.error(err);
             }
         });

--- a/InboxScanner.js
+++ b/InboxScanner.js
@@ -65,7 +65,7 @@ var InboxScanner = class {
                 if (msg.status_code === 200) {
                     const folders = this._scanner.parseResponse(body, callback);
                     callback(null, folders, this._account);
-                } else {
+                } else if (msg.status_code !== 2 && msg.status_code !== 3) {
                     const err = new Error('Status ' + msg.status_code + ': ' + msg.reason_phrase);
                     callback(err);
                 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,5 @@
   ],
   "url": "https://github.com/shumingch/gnome-email-notifications",
   "uuid": "GmailMessageTray@shuming0207.gmail.com",
-  "version": 23
+  "version": 24
 }


### PR DESCRIPTION
If there is no internet access, Soup will return a status code of either 2 or 3 (see https://gjs-docs.gnome.org/soup24~2.72.0/soup.status#default-cant_resolve). Displaying a "Failed to get authorization" message in this case seems unnecessary.