### PR TITLE
Added Gnome 44 in Supported Shell Versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "name": "Gnome Email Notifications",
   "description": "Shows Gmail and Outlook notifications in Gnome Message Tray using Gnome Online Accounts\n",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/shumingch/gnome-email-notifications",
   "uuid": "GmailMessageTray@shuming0207.gmail.com",


### PR DESCRIPTION
- Extension Works on Gnome 44 (Tested on Ubuntu 23.04)
- Just Added 44 in the supported "shell-version"

![image](https://user-images.githubusercontent.com/42410225/233828720-e280c1f1-9753-44fa-ac57-b8d518f847ad.png)
![image](https://user-images.githubusercontent.com/42410225/233828514-b759b8a2-c2c1-4d75-8935-0db29d59d6b7.png)
![image](https://user-images.githubusercontent.com/42410225/233828544-b9545c2f-a3df-46e3-bbc4-99e3ffb14cfa.png)


