### PR TITLE
Fix #46.

### DIFF
--- a/InboxScanner.js
+++ b/InboxScanner.js
@@ -35,8 +35,9 @@ var InboxScanner = class {
      * Creates a new scanner using a Gnome Online Account
      * @param account - Gnome Online Account
      * @param {Conf} config - the extension configuration
+     * @param {number} [timeout=1] - the request timeout in seconds (optional, default is 1 second)
      */
-    constructor(account, config) {
+    constructor(account, config, timeout = 1) {
         this._config = config;
 
         this._account = account;
@@ -45,6 +46,7 @@ var InboxScanner = class {
         this._scanner = this._createScanner();
         this._sess = new Soup.Session();
         this._console = new Console();
+        this._sess.set_timeout(timeout);       
     }
 
     /**


### PR DESCRIPTION
Fixes #46 by increasing the request timeout to 1s. 

Output of `journalctl /usr/bin/gnome-shell | grep 'Status 0'`

![Fix](https://github.com/shumingch/gnome-email-notifications/assets/7200161/63f1533a-8620-40b2-b8a2-290497435ad9)

Tested on Fedora 38, Gnome 44.3